### PR TITLE
Use java-compatible cipher

### DIFF
--- a/kafka-ssl/security/create-pem-certificate.sh
+++ b/kafka-ssl/security/create-pem-certificate.sh
@@ -16,6 +16,7 @@ openssl pkcs8 \
   -topk8 \
   -in $certname.key \
   -inform pem \
+  -v1 PBE-SHA1-RC4-128 \
   -out $certname-pkcs8.key \
   -outform pem \
   -passin pass:$password \


### PR DESCRIPTION
OpenSSL 1.1.1g uses cipher that java does not support

Closes https://github.com/codingharbour/kafka-docker-compose/issues/4