### PR TITLE
Draft: Use unecrypted private keys

### DIFF
--- a/kafka-ssl/docker-compose.yml
+++ b/kafka-ssl/docker-compose.yml
@@ -46,10 +46,8 @@ services:
       KAFKA_ZOOKEEPER_SSL_CLIENT_ENABLE: 'true'
       KAFKA_ZOOKEEPER_CLIENT_CNXN_SOCKET: org.apache.zookeeper.ClientCnxnSocketNetty
       KAFKA_ZOOKEEPER_SSL_KEYSTORE_LOCATION: /etc/kafka/secrets/broker-keypair.pem
-      KAFKA_ZOOKEEPER_SSL_KEYSTORE_PASSWORD: codingharbour
       KAFKA_ZOOKEEPER_SSL_KEYSTORE_TYPE: PEM
       KAFKA_ZOOKEEPER_SSL_TRUSTSTORE_LOCATION: /etc/kafka/secrets/root.crt
-      KAFKA_ZOOKEEPER_SSL_TRUSTSTORE_PASSWORD: codingharbour
       KAFKA_ZOOKEEPER_SSL_TRUSTSTORE_TYPE: PEM
 
       # option 1: provide certs as strings
@@ -57,14 +55,12 @@ services:
       # KAFKA_SSL_KEYSTORE_TYPE: PEM
       # KAFKA_SSL_KEYSTORE_CERTIFICATE_CHAIN: -----BEGIN CERTIFICATE-----\nMII....\n-----END CERTIFICATE-----
       # KAFKA_SSL_KEYSTORE_KEY: -----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIE...\n-----END ENCRYPTED PRIVATE KEY-----
-      # KAFKA_SSL_KEY_PASSWORD: codingharbour
       # KAFKA_SSL_TRUSTSTORE_TYPE: PEM
       # KAFKA_SSL_TRUSTSTORE_CERTIFICATES: -----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----
 
       # option 2: use pem files
 
       KAFKA_SSL_KEYSTORE_LOCATION: /etc/kafka/secrets/broker-keypair.pem
-      KAFKA_SSL_KEY_PASSWORD: codingharbour
       KAFKA_SSL_KEYSTORE_TYPE: PEM
       KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/kafka/secrets/root.crt
       KAFKA_SSL_TRUSTSTORE_TYPE: PEM

--- a/kafka-ssl/security/create-pem-certificate.sh
+++ b/kafka-ssl/security/create-pem-certificate.sh
@@ -1,14 +1,12 @@
 #! /bin/bash
 
 certname=$1
-password=codingharbour
 
 openssl req -newkey \
   rsa:2048 \
+  -noenc \
   -keyout $certname.key \
   -out $certname.csr \
-  -passin pass:$password \
-  -passout pass:$password \
   -subj "/CN=$certname/OU=TEST/O=CodingHarbour/L=Oslo/C=NO"
 
 #convert the key to PKCS8, otherwise kafka/java cannot read it
@@ -16,11 +14,9 @@ openssl pkcs8 \
   -topk8 \
   -in $certname.key \
   -inform pem \
-  -v1 PBE-SHA1-RC4-128 \
   -out $certname-pkcs8.key \
   -outform pem \
-  -passin pass:$password \
-  -passout pass:$password
+  -nocrypt
 
 mv $certname-pkcs8.key $certname.key
 
@@ -33,7 +29,6 @@ openssl x509 -req \
   -sha256 \
   -days 365 \
   -CAcreateserial \
-  -passin pass:$password \
   -extensions v3_req \
   -extfile <(cat <<EOF
 [req]


### PR DESCRIPTION
After https://github.com/apache/kafka/pull/11916 is implemented, it is possible to use PEM certificates with unencrypted private keys, which simplifies the deployment to e.g. kubernetes. 